### PR TITLE
fix: add %dev http.port override (19000 -> 19100)

### DIFF
--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -24,3 +24,5 @@ quarkus.http.http2.max-concurrent-streams=2000
 %test.quarkus.http.port=0
 %test.quarkus.grpc.server.test-port=0
 %test.quarkus.dynamic-grpc.service.echo.address=localhost:${quarkus.grpc.server.test-port}
+
+%dev.quarkus.http.port=19100


### PR DESCRIPTION
Adds a `%dev` profile override so dev mode listens on 19100 while the
base port (19000) stays reserved for non-dev profiles. Aligns with the
project-wide connector / sink / processing-module convention of
base+100 in dev.

## Summary
- Single-line addition to `application.properties`.

## Test plan
- [x] Before change, `quarkus dev` bound 19000.
- [ ] With this change, `quarkus dev` binds 19100 and process-compose readiness probe succeeds.