### PR TITLE
chore: remove stale 0.7.21-SNAPSHOT fallback for pipestreamBomVersion

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -10,7 +10,7 @@ plugins {
     alias(libs.plugins.proto.toolchain)
 }
 
-def pipestreamBomVersion = findProperty('pipestreamBomVersion') ?: '0.7.21-SNAPSHOT'
+def pipestreamBomVersion = findProperty('pipestreamBomVersion')
 
 // Axion-release configuration for automatic versioning
 scmVersion {


### PR DESCRIPTION
Match prevailing style in pipestream-engine / repository-service / module-chunker: require the property to be set via gradle.properties, fail dep resolution if missing. Removes the long-abandoned 0.7.21-SNAPSHOT fallback that silently masked a missing config.